### PR TITLE
Webhook RBAC template bug

### DIFF
--- a/incubator/instana-autotrace-webhook/templates/deployment.yml
+++ b/incubator/instana-autotrace-webhook/templates/deployment.yml
@@ -15,7 +15,7 @@ spec:
   replicas: {{ .Values.webhook.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/instance: instana-autotrace-webhook
+      app.kubernetes.io/instance: {{ .Release.Name }}
   strategy:
     # Since we bind to the host network, a rolling update on small clusters may deadlock,
     # with new pods not able to start because the network port is taken, and old pods remaining

--- a/incubator/instana-autotrace-webhook/templates/mutating-webhook-rbac.yaml
+++ b/incubator/instana-autotrace-webhook/templates/mutating-webhook-rbac.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "instana-autotrace-webhook.commonLabels" . | nindent 4 }}


### PR DESCRIPTION
This will fix the [Issue](https://github.com/instana/instana-autotrace-webhook/issues/4) 4.

If fixes the Name of the Service Account and the name of the app.kubernetes.io/instance.