### PR TITLE
Fix indentation of additionalLabels

### DIFF
--- a/incubator/instana-autotrace-webhook/templates/service.yaml
+++ b/incubator/instana-autotrace-webhook/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
 {{- include "instana-autotrace-webhook.commonLabels" . | nindent 4 }}
 {{- if .Values.webhook.service.additionalLabels }}
-{{ toYaml .Values.webhook.service.additionalLabels | indent 6 }}
+{{ toYaml .Values.webhook.service.additionalLabels | indent 4 }}
 {{- end }}
   annotations:
 {{- if .Values.openshift.enabled }}


### PR DESCRIPTION
Currently, when you add an additionalLabel to the service, you'll receive this error while installing the helm chart
`Error: INSTALLATION FAILED: YAML parse error on instana-autotrace-webhook/templates/service.yaml: error converting YAML to JSON: yaml: line 10: mapping values are not allowed in this context` 

This is due to the misconfigured indentation
`{{ toYaml .Values.webhook.service.additionalLabels | indent 6 }}` which should only be indented `4` tabs deep, just like in the deployment.

This PR fixes this.