### PR TITLE
fix: update serving-cert-secret-name annotation to match secret used by deployment

### DIFF
--- a/incubator/instana-autotrace-webhook/templates/service.yaml
+++ b/incubator/instana-autotrace-webhook/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
 {{- end }}
   annotations:
 {{- if .Values.openshift.enabled }}
-    service.beta.openshift.io/serving-cert-secret-name: instana-autotrace-webhook-certs
+    service.beta.openshift.io/serving-cert-secret-name: {{ include "instana-autotrace-webhook.tlsSecretName" . }}
 {{- end }}
 {{- if .Values.webhook.service.additionalAnnotations }}
 {{ toYaml .Values.webhook.service.additionalAnnotations | indent 4 }}


### PR DESCRIPTION
Annotation needs to match the secret referenced in the [Deployment](https://github.com/instana/instana-autotrace-webhook/blob/4e0a26f6730dd4e2aec1adb1111d80d890c2bb1f/incubator/instana-autotrace-webhook/templates/deployment.yml#L241)